### PR TITLE
fpr: Canon, Snap, dget, Logitech, kolide, terraform, docker

### DIFF
--- a/detection/c2/unexpected-dns-traffic-events.sql
+++ b/detection/c2/unexpected-dns-traffic-events.sql
@@ -26,8 +26,7 @@ SELECT
   s.pid,
   p.parent AS parent_pid,
   pp.cmdline AS parent_cmd,
-  hash.sha256,
-  CONCAT (p.name, ',', remote_address, ',', remote_port) AS exception_key
+  hash.sha256
 FROM
   socket_events s
   LEFT JOIN processes p ON s.pid = p.pid
@@ -62,99 +61,108 @@ WHERE
   )
   -- Some applications hard-code a safe DNS resolver, or allow the user to configure one
   AND s.remote_address NOT IN (
-    '1.1.1.1', -- Cloudflare
+    '0.0.0.0',
     '100.100.100.100', -- Tailscale Magic DNS
+    '1.0.0.1', -- Cloudflare
+    '1.1.1.1', -- Cloudflare
+    '1.1.1.2', -- Cloudflare
+    '185.125.190.31', -- Canonical
+    '185.125.190.77', -- Canonical
     '208.67.220.123', -- OpenDNS FamilyShield
+    '208.67.222.222', -- OpenDNS
+    '34.160.111.32', -- wolfi.dev
+    '68.105.28.13', -- Cox
     '75.75.75.75', -- Comcast
     '75.75.76.76', -- Comcast
-    '68.105.28.13', -- Cox
     '80.248.7.1', -- 21st Century (NG)
-    '34.160.111.32', -- wolfi.dev
-    '185.125.190.31', -- Canonical
-    '185.125.190.77' -- Canonical
-  )
-  -- Exceptions that specifically talk to one server
-  AND exception_key NOT IN (
-    'adguard_dns,1.0.0.1,53',
-    'AssetCacheLocatorService,0.0.0.0,53',
-    'brave,8.8.8.8,53',
-    'CapCut,8.8.8.8,53',
-    'cg,108.177.98.95,53',
-    'ChatGPT,8.8.8.8,53',
-    'com.docker.backend,8.8.8.8,53',
-    'com.docker.vpnkit,8.8.8.8,53',
-    'coredns,0.0.0.0,53',
-    'coredns,8.8.8.8,53',
-    'Creative Cloud Content Manager.node,8.8.4.4,53',
-    'Creative Cloud Content Manager.node,8.8.8.8,53',
-    'distnoted,8.8.4.4,53',
-    'distnoted,8.8.8.8,53',
-    'dockerd,162.159.140.238,53',
-    'EpicWebHelper,8.8.4.4,53',
-    'EpicWebHelper,8.8.8.8,53',
-    'gvproxy,170.247.170.2,53',
-    'helm,185.199.108.133,53',
-    'limactl,8.8.8.8,53',
-    'Meeting Center,8.8.8.8,53',
-    'msedge,8.8.4.4,53',
-    'msedge,8.8.8.8,53',
-    'node,149.22.90.225,5353',
-    'nuclei,1.0.0.1,53',
-    'Pieces OS,8.8.4.4,53',
-    'Pieces OS,208.67.222.222,53',
-    'plugin-container,8.8.8.8,53',
-    'ServiceExtension,8.8.8.8,53',
-    'signal-desktop,8.8.8.8,53',
-    'Signal Helper (Renderer),8.8.8.8,53',
-    'slack,8.8.8.8,53',
-    'snapd,185.125.188.54,53',
-    'snapd,185.125.188.55,53',
-    'snapd,185.125.188.58,53',
-    'snapd,185.125.188.59,53',
-    'Socket Process,8.8.8.8,53',
-    'syncthing,46.162.192.181,53',
-    'Telegram,8.8.8.8,53',
-    'WebexHelper,8.8.8.8,53',
-    'WhatsApp,1.1.1.1,53',
-    'yum,208.67.222.222,53',
-    'ZaloCall,8.8.8.8,53',
-    'zed,8.8.8.8,53',
-    'ZoomPhone,200.48.225.130,53',
-    'ZoomPhone,200.48.225.146,53',
-    'ZoomPhone,8.8.8.8,53'
+    '185.199.108.154' -- GitHub
   )
   -- Local DNS servers and custom clients go here
   AND basename NOT IN (
     'adguard_dns',
-    'apk',
     'agentbeat',
+    'apk',
     'apko',
+    'AssetCacheLocatorService',
+    'Beeper Desktop',
+    'brave',
+    'buildkitd',
     'canonical-livep',
+    'CapCut',
+    'cg',
+    'chainctl',
+    'ChatGPT',
     'chrome',
+    'chromium',
+    'cloudcode_cli',
+    'git-lfs',
+    'Code Helper (Plugin)',
     'com.apple.WebKit.Networking',
     'com.docker.backend',
+    'com.docker.buil',
+    'com.docker.build',
+    'com.docker.vpnkit',
+    'com.nordvpn.macos.helper',
+    'containerd',
+    'coredns',
+    'Creative Cloud Content Manager.node',
+    'distnoted',
+    'docker-language-server-linux-amd64',
+    'docker',
+    'dockerd',
+    'drkonqi-coredump-processor',
+    'eksctl',
+    'EpicWebHelper',
     'go',
-    'wolfictl',
-    'gvproxy',
     'grype',
-    'incusd',
+    'gvproxy',
     'helm',
-    'terraform-provi',
+    'incusd',
+    'io.tailscale.ipn.macsys.network-extension',
     'IPNExtension',
     'Jabra Direct Helper',
+    'java',
+    'launcher',
     'limactl',
+    'librewolf',
     'mDNSResponder',
+    'Meeting Center',
     'melange',
-    'syncthing',
+    'msedge',
     'nessusd',
+    'node',
     'nuclei',
+    'ollama',
+    'Pieces OS',
+    'plugin-container',
+    'ServiceExtension',
+    'Signal Helper (Renderer)',
+    'signal-desktop',
+    'slack',
+    'snapd',
+    'Socket Process',
+    'syncthing',
     'systemd-resolved',
-    'WhatsApp'
+    'tailscaled',
+    'Telegram',
+    'terraform',
+    'terraform-ls',
+    'terraform-provi',
+    'vunnel',
+    'WebexHelper',
+    'WhatsApp',
+    'wolfictl',
+    'yum',
+    'ZaloCall',
+    'zed',
+    'ZoomPhone'
   )
-  AND p.name NOT IN ('Jabra Direct Helper', 'terraform-provi')
   -- Chromium/Electron apps seem to send stray packets out like nobodies business
-  AND p.path NOT LIKE '%/%.app/Contents/MacOS/% Helper'
+  AND basename NOT LIKE '% Helper'
+  AND basename NOT LIKE 'terraform-provider-%'
+  AND p.name != 'terraform-provi'
   AND p.path NOT LIKE '/snap/%'
+  AND pp.path NOT IN ('/usr/bin/containerd-shim-runc-v2')
   -- Workaround for the GROUP_CONCAT subselect adding a blank ent
 GROUP BY
   s.remote_address,


### PR DESCRIPTION
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3

## Summary by Sourcery

Refine the unexpected DNS traffic detection query by removing the deprecated exception_key logic, broadening whitelists of known DNS resolvers and trusted client processes, and tightening path-based filters for helper and provider binaries.

Enhancements:
- Remove the CONCAT-based exception_key column and its associated filters
- Expand the DNS resolver IP exclusion list with additional Cloudflare, Canonical, OpenDNS, GitHub, wolfi.dev, and Cox addresses
- Add numerous trusted process basenames (e.g., Terraform, Snapd, AssetCacheLocatorService, Tailscale, and others) to the whitelist
- Update path filters to skip Terraform provider patterns and exclude the containerd shim helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved detection accuracy for unexpected DNS traffic by expanding the list of known safe DNS resolvers and client applications.
	- Reduced false positives by refining filtering criteria and simplifying exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->